### PR TITLE
Use header file for constructor definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(SOURCE_FILES
         src/gui/pages/generalpage.cpp
         src/gui/pages/generalpage.h
         src/gui/pages/configurationpage.h
-        src/gui/pages/configurationpage.cpp
         src/gui/pages/agentspage.cpp
         src/gui/pages/agentspage.h
         src/launch/launcher.h

--- a/src/gui/pages/configurationpage.cpp
+++ b/src/gui/pages/configurationpage.cpp
@@ -1,8 +1,0 @@
-//
-// Created by nils on 11/5/21.
-//
-
-#include "configurationpage.h"
-
-ConfigurationPage::ConfigurationPage(Config& config, QWidget *parent) : config(config), QWidget(parent){
-}

--- a/src/gui/pages/configurationpage.h
+++ b/src/gui/pages/configurationpage.h
@@ -22,7 +22,7 @@ public:
     virtual void load() = 0;
 
 protected:
-    explicit ConfigurationPage(Config& config, QWidget* parent);
+    explicit ConfigurationPage(Config& config, QWidget* parent) : config(config), QWidget(parent) {};
 
     Config& config;
 };


### PR DESCRIPTION
This pull request removes the `configurationpage.cpp` in favour of using the respective header file

I have tested the changes on macOS v12.0.1