### PR TITLE
chore: use same bracing for `foreach`

### DIFF
--- a/src/launch/offlinelauncher.cpp
+++ b/src/launch/offlinelauncher.cpp
@@ -51,9 +51,10 @@ void OfflineLauncher::launch(bool cosmetics) {
         }).join(QDir::listSeparator())
     };
 
-    foreach(const QString& path, config.agents)
+    foreach(const QString& path, config.agents) {
         args << "-javaagent:" + path;
-
+    }
+               
     if(config.useAutoggMessage)
         args << getAgentFlags(
                 QTemporaryFile::createNativeFile(":/res/CustomAutoGG.jar")->fileName(),


### PR DESCRIPTION
Reason for PR:
Use the same convention for `foreach` like in https://github.com/Nilsen84/lunar-client-qt/blob/master/src/config/config.cpp#L53